### PR TITLE
Fix submodules url protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Torsten Scholak - Bayesian Machine Learning"]
 	path = Torsten Scholak - Bayesian Machine Learning
-	url = git@github.com:UnataInc/PyCon2017
+	url = https://github.com/UnataInc/PyCon2017
 [submodule "Filipe_Pires_Alvarenga_conda-forge"]
 	path = Filipe_Pires_Alvarenga_conda-forge
 	url = https://github.com/ocefpaf/talk_pycon2017


### PR DESCRIPTION
Using the https protocol.

If use git protocol,  there will be some problems.

```
(Tao) ➜  2017-slides git:(master) ✗ git submodule update
Cloning into '/Users/tao/workspace/2017-slides/Filipe_Pires_Alvarenga_conda-forge'...
Cloning into '/Users/tao/workspace/2017-slides/Torsten Scholak - Bayesian Machine Learning'...
ssh_exchange_identification: read: Connection reset by peer
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:UnataInc/PyCon2017' into submodule path '/Users/tao/workspace/2017-slides/Torsten Scho
lak - Bayesian Machine Learning' failed
```